### PR TITLE
Remove extra whitespace from unclassified_job (#12)

### DIFF
--- a/tests/test_unclassified_job.py
+++ b/tests/test_unclassified_job.py
@@ -25,7 +25,7 @@ class TestUnclassifiedJobs:
 
         teststatus = resultset_page.job_result_status
         jobstatus = ["busted", "testfailed"]
-        
+
         for i in range(len(jobstatus)):
             'assert jobstatus in teststatus'
 


### PR DESCRIPTION
This addresses Issue #12. I just noticed this extra whitespace in passing, so removing it.