### PR TITLE
Add exception as a failure type for navigation (#15)

### DIFF
--- a/tests/test_unclassified_job.py
+++ b/tests/test_unclassified_job.py
@@ -24,7 +24,7 @@ class TestUnclassifiedJobs:
         resultset_page.open_next_unclassified_failure()
 
         teststatus = resultset_page.job_result_status
-        jobstatus = ["busted", "testfailed"]
+        jobstatus = ["busted", "testfailed", "exception"]
 
         for i in range(len(jobstatus)):
             'assert jobstatus in teststatus'


### PR DESCRIPTION
This fixes issue #15.

In it we add the 'exception' failure type, so we find purple exceptions in case they are the only failures in mozilla-inbound. In that scenario we'd correctly have a working and passing test.

Adding @rbillings and @m8ttyB for review.