### PR TITLE
Add Jenkinsfile pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,152 @@
+import groovy.json.JsonOutput
+
+/** Tox environment */
+def environment = 'tests'
+
+/** Map of desired capabilities */
+def capabilities = [
+  browserName: 'Firefox',
+  version: '47.0',
+  platform: 'Windows 7'
+]
+
+/** Write capabilities to JSON file
+ *
+ * @param desiredCapabilities capabilities to include in the file
+*/
+def writeCapabilities(desiredCapabilities) {
+    def defaultCapabilities = [
+        build: env.BUILD_TAG,
+        public: 'public restricted'
+    ]
+    def capabilities = defaultCapabilities.clone()
+    capabilities.putAll(desiredCapabilities)
+    def json = JsonOutput.toJson([capabilities: capabilities])
+    writeFile file: 'capabilities.json', text: json
+}
+
+/** Run Tox
+ *
+ * @param environment test environment to run
+*/
+def runTox(environment) {
+  try {
+    wrap([$class: 'AnsiColorBuildWrapper']) {
+      withCredentials([[
+        $class: 'StringBinding',
+        credentialsId: 'SAUCELABS_API_KEY',
+        variable: 'SAUCELABS_API_KEY']]) {
+        withEnv(["PYTEST_ADDOPTS=${PYTEST_ADDOPTS} " +
+          "--base-url=${PYTEST_BASE_URL} " +
+          "--driver=SauceLabs " +
+          "--variables=capabilities.json " +
+          "--color=yes"]) {
+          sh "tox -e ${environment}"
+        }
+      }
+    }
+  } catch(err) {
+    currentBuild.result = 'FAILURE'
+    throw err
+  } finally {
+    dir('results') {
+      stash environment
+    }
+  }
+}
+
+/** Send a notice to #fxtest-alerts on irc.mozilla.org with the build result
+ *
+ * @param result outcome of build
+*/
+def ircNotification(result) {
+  def nick = "fxtest${BUILD_NUMBER}"
+  def channel = '#fx-test-alerts'
+  result = result.toUpperCase()
+  def message = "Project ${JOB_NAME} build #${BUILD_NUMBER}: ${result}: ${BUILD_URL}"
+  node {
+    sh """
+        (
+        echo NICK ${nick}
+        echo USER ${nick} 8 * : ${nick}
+        sleep 5
+        echo "JOIN ${channel}"
+        echo "NOTICE ${channel} :${message}"
+        echo QUIT
+        ) | openssl s_client -connect irc.mozilla.org:6697
+    """
+  }
+}
+
+stage('Checkout') {
+  node {
+    timestamps {
+      deleteDir()
+      checkout scm
+      stash 'workspace'
+    }
+  }
+}
+
+stage('Lint') {
+  node {
+    timestamps {
+      deleteDir()
+      unstash 'workspace'
+      sh 'tox -e flake8'
+    }
+  }
+}
+
+try {
+  stage('Test') {
+    node {
+      timeout(time: 1, unit: 'HOURS') {
+        timestamps {
+          deleteDir()
+          unstash 'workspace'
+          try {
+            writeCapabilities(capabilities)
+            runTox(environment)
+          } catch(err) {
+            currentBuild.result = 'FAILURE'
+            throw err
+          } finally {
+            dir('results') {
+              stash environment
+            }
+          }
+        }
+      }
+    }
+  }
+} catch(err) {
+  currentBuild.result = 'FAILURE'
+  ircNotification(currentBuild.result)
+  mail(
+    body: "${BUILD_URL}",
+    from: "firefox-test-engineering@mozilla.com",
+    replyTo: "firefox-test-engineering@mozilla.com",
+    subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}",
+    to: "fte-ci@mozilla.com")
+  throw err
+} finally {
+  stage('Results') {
+    node {
+      deleteDir()
+      sh 'mkdir results'
+      dir('results') {
+        unstash environment
+      }
+      publishHTML(target: [
+        allowMissing: false,
+        alwaysLinkToLastBuild: true,
+        keepAll: true,
+        reportDir: 'results',
+        reportFiles: "${environment}.html",
+        reportName: 'HTML Report'])
+      junit 'results/*.xml'
+      archiveArtifacts 'results/*'
+    }
+  }
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[flake8]
-ignore=E501
-
-[tool:pytest]
-addopts=-n=auto --verbose -r=a --driver=Firefox --junit-xml=results/junit.xml --html=results/index.html
-testpaths=tests
-xfail_strict=true
-base_url=https://treeherder.allizom.org
-sensitive_url=mozilla\.org

--- a/tox.ini
+++ b/tox.ini
@@ -3,16 +3,29 @@ skipsdist = true
 envlist = tests, flake8
 
 [testenv]
-passenv = PYTEST_ADDOPTS DISPLAY
+passenv = DISPLAY PYTEST_ADDOPTS SAUCELABS_API_KEY SAUCELABS_USERNAME
 deps =
     bidpom
     PyPOM
     pytest~=3.0.0
     pytest-selenium
     pytest-xdist==1.15.0
-commands = pytest {posargs}
+commands = pytest \
+    --junit-xml=results/{envname}.xml \
+    --html=results/{envname}.html \
+    {posargs}
 
 [testenv:flake8]
 skip_install = true
 deps = flake8
 commands = flake8 {posargs:.}
+
+[flake8]
+ignore = E501
+
+[pytest]
+addopts = -n=auto --verbose -r=a --driver=Firefox
+testpaths = tests
+xfail_strict = true
+base_url = https://treeherder.allizom.org
+sensitive_url = mozilla\.org


### PR DESCRIPTION
This moves a lot of the Jenkins job configuration into the repository as a Groovy script, which gives us better tracking of changes, and allows changes to the target platforms and build without needing to grant permissions in Jenkins and use their dashboard. An overview of Jenkins pipelines can be found [here](https://jenkins.io/doc/book/pipeline/overview/).

Please note that we'll need to update the Jenkins job configuration (hopefully for one of the last times) after merging this. I'm happy to take care of this, so feel free to review and leave the merge to me.

Adhoc: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/treeherder.pipeline.adhoc/6/

@stephendonner @rpappalax r?
/cc @rbillings @MichalTHEDUDE