### PR TITLE
Update to Windows 10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def environment = 'tests'
 def capabilities = [
   browserName: 'Firefox',
   version: '47.0',
-  platform: 'Windows 7'
+  platform: 'Windows 10'
 ]
 
 /** Write capabilities to JSON file


### PR DESCRIPTION
This puts on a more-recent Windows versions, but by itself it shouldn't and doesn't seem to change test stability.  We've also done it for https://github.com/mozilla/Addon-Tests/pull/907 and https://github.com/mozilla/mozillians-tests/pull/275 but it's your call, @rbillings 

Thoughts?  r?