### PR TITLE
Fix to address job_details and clear_pinboard failures

### DIFF
--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -407,9 +407,9 @@ class TreeherderPage(Base):
             return LogviewerPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 
         def pin_job(self):
-            el = self.find_element(*self._pin_job_locator)
+            el = self.find_element(*self._job_keyword_locator)
             self.wait.until(EC.visibility_of(el))
-            el.click()
+            self.find_element(*self._pin_job_locator).click()
 
     class Pinboard(Region):
 

--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -19,11 +19,13 @@ class TreeherderPage(Base):
     _clear_filter_locator = (By.ID, 'quick-filter-clear-button')
     _close_the_job_panel_locator = (By.CSS_SELECTOR, '.info-panel-navbar-controls > li:nth-child(2)')
     _filter_panel_all_failures_locator = (By.CSS_SELECTOR, '.pull-right input')
+    _filter_panel_body_locator = (By.CSS_SELECTOR, '.th-top-nav-options-panel')
     _filter_panel_busted_failures_locator = (By.ID, 'busted')
     _filter_panel_exception_failures_locator = (By.ID, 'exception')
     _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
     _filter_panel_reset_locator = (By.CSS_SELECTOR, '.pull-right span:nth-child(3)')
     _filter_panel_testfailed_failures_locator = (By.ID, 'testfailed')
+    _info_panel_content_locator = (By.ID, 'info-panel-content')
     _mozilla_central_repo_locator = (By.CSS_SELECTOR, '#th-global-navbar-top a[href*="mozilla-central"]')
     _nav_filter_coalesced_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=coalesced]')
     _nav_filter_failures_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=failures]')
@@ -70,8 +72,18 @@ class TreeherderPage(Base):
         return self.find_element(*self._filter_panel_testfailed_failures_locator).is_selected()
 
     @property
+    def filter_panel_is_open(self):
+        el = self.find_element(*self._filter_panel_body_locator)
+        return el.is_displayed()
+
+    @property
     def job_details(self):
         return self.JobDetails(self)
+
+    @property
+    def info_panel_is_open(self):
+        el = self.find_element(*self._info_panel_content_locator)
+        return el.is_displayed()
 
     @property
     def nav_filter_coalesced_is_selected(self):
@@ -117,6 +129,11 @@ class TreeherderPage(Base):
         return [self.ResultSet(self, el) for el in self.find_elements(*self._result_sets_locator)]
 
     @property
+    def search_term(self):
+        el = self.find_element(*self._quick_filter_locator)
+        return el.get_attribute('value')
+
+    @property
     def unchecked_repos(self):
         return self.find_elements(*self._unchecked_repos_links_locator)
 
@@ -124,8 +141,14 @@ class TreeherderPage(Base):
     def unclassified_failure_count(self):
         return int(self.find_element(*self._unclassified_failure_count_locator).text)
 
-    def clear_filter(self):
-        self.selenium.find_element(*self._clear_filter_locator).click()
+    def clear_filter(self, method='pointer'):
+        if method == 'pointer':
+            self.selenium.find_element(*self._clear_filter_locator).click()
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                Keys.CONTROL + Keys.SHIFT + 'f')
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
 
     def click_on_filters_panel(self):
         self.find_element(*self._filter_panel_locator).click()
@@ -136,6 +159,9 @@ class TreeherderPage(Base):
 
     def close_the_job_panel(self):
         self.find_element(*self._close_the_job_panel_locator).click()
+
+    def close_all_panels(self):
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ESCAPE)
 
     def deselect_all_failures(self):
         """Filters Panel must be opened"""
@@ -153,11 +179,17 @@ class TreeherderPage(Base):
         """Filters Panel must be opened"""
         self.find_element(*self._filter_panel_testfailed_failures_locator).click()
 
-    def filter_by(self, term):
-        el = self.selenium.find_element(*self._quick_filter_locator)
-        el.send_keys(term)
-        el.send_keys(Keys.RETURN)
-        self.wait.until(lambda s: self.result_sets)
+    def filter_by(self, term, method='pointer'):
+        if method == 'pointer':
+            el = self.selenium.find_element(*self._quick_filter_locator)
+            el.send_keys(term)
+            el.send_keys(Keys.RETURN)
+            self.wait.until(lambda s: self.result_sets)
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                'f' + term + Keys.RETURN)
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
 
     def filter_job_coalesced(self):
         self.find_element(*self._nav_filter_coalesced_locator).click()

--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -414,7 +414,7 @@ class TreeherderPage(Base):
     class Pinboard(Region):
 
         _root_locator = (By.ID, 'pinboard-panel')
-        _clear_all_menu_locator = (By.CSS_SELECTOR, '#pinboard-controls .dropdown-menu li:nth-child(4)')
+        _clear_all_menu_locator = (By.CSS_SELECTOR, '#pinboard-controls .dropdown-menu li:nth-child(5) a')
         _jobs_locator = (By.CLASS_NAME, 'pinned-job')
         _open_save_menu_locator = (By.CSS_SELECTOR, '#pinboard-controls .save-btn-dropdown')
         _pinboard_remove_job_locator = (By.CSS_SELECTOR, '#pinned-job-list .pinned-job-close-btn')

--- a/tests/test_keyboard_shortcuts.py
+++ b/tests/test_keyboard_shortcuts.py
@@ -7,6 +7,53 @@ import random
 from pages.treeherder import TreeherderPage
 
 
+def test_close_open_panels(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'Esc' closes filter and job panel.
+    Open Treeherder page, open Filters panel, select random job, close all
+    panels using 'esc' button, verify if all panels are closed.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.click_on_filters_panel()
+    page.select_random_job()
+
+    assert page.filter_panel_is_open
+    assert page.info_panel_is_open
+
+    page.close_all_panels()
+
+    assert not page.filter_panel_is_open
+    assert not page.info_panel_is_open
+
+
+def test_enter_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'f' moves cursor to filter search box.
+    Open Treeherder page, verify if search box is empty, enter search box
+    filter using 'f' shortcut, type 'debug', verify if filter box contains
+    word Mozilla.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+    assert page.search_term == ''
+
+    page.filter_by('debug', method='keyboard')
+    assert page.search_term == 'debug'
+
+
+def test_clear_the_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: CTRL + SHIFT + 'f' clears the filter search box.
+    Open Treeherder page, filter by 'Mozdebugilla', verify if filter box contains the
+    word 'debug', clear the quick filter using CTRL + SHIFT + f shortcut,
+    verify if search box is empty.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.filter_by('debug', method='keyboard')
+    assert page.search_term == 'debug'
+
+    page.clear_filter(method='keyboard')
+    assert page.search_term == ''
+
+
 def test_next_job_shortcut(base_url, selenium):
     """Open Treeherder, verify shortcut: 'Right Arrow' opens next job.
     Open Treeherder page, select random job and get the keyword name, select next job


### PR DESCRIPTION
This job was failing as the job_details pane was open but the data hadn't fully loaded when the test tried to add it to the pinboard. This change should get both pinboard tests passing.