### PR TITLE
Returned set and added wait

### DIFF
--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -96,6 +96,7 @@ class TreeherderPage(Base):
 
     def click_on_active_watched_repo(self):
         self.find_element(*self._active_watched_repo_locator).click()
+        self.wait_for_page_to_load()
 
     def close_the_job_panel(self):
         self.find_element(*self._close_the_job_panel_locator).click()

--- a/tests/test_filter_job_by_email.py
+++ b/tests/test_filter_job_by_email.py
@@ -30,4 +30,4 @@ def test_remove_email_address_filter(base_url, selenium):
     page.click_on_active_watched_repo()
     all_emails = [email.get_name for email in page.all_emails]
 
-    assert len(all_emails) > 1
+    assert len(set(all_emails)) > 1


### PR DESCRIPTION
This is to correct the removal of set here*, with an added wait as the test was failing before the page loaded.

* https://github.com/mozilla/treeherder-tests/pull/109#pullrequestreview-19051241