### PR TITLE
Move job_details region under info_panel

### DIFF
--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -25,6 +25,7 @@ class TreeherderPage(Base):
     _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
     _filter_panel_reset_locator = (By.CSS_SELECTOR, '.pull-right span:nth-child(3)')
     _filter_panel_testfailed_failures_locator = (By.ID, 'testfailed')
+    _info_panel_content_locator = (By.ID, 'info-panel-content')
     _mozilla_central_repo_locator = (By.CSS_SELECTOR, '#th-global-navbar-top a[href*="mozilla-central"]')
     _nav_filter_coalesced_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=coalesced]')
     _nav_filter_failures_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=failures]')
@@ -375,15 +376,6 @@ class TreeherderPage(Base):
                 self.wait.until(lambda _: self.page.info_panel.job_details.job_result_status)
 
     class InfoPanel(Region):
-
-        _root_locator = (By.ID, 'info-panel-content')
-
-        @property
-        def is_open(self):
-            return self.root.is_displayed()
-
-    class JobDetails(Region):
-        """TODO: Move region under InfoPanel"""
 
         _root_locator = (By.ID, 'info-panel-content')
 

--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -393,11 +393,11 @@ class TreeherderPage(Base):
 
         @property
         def job_details(self):
-            return self.JobDetails(self)
+            return self.JobDetails(self.page)
 
         class JobDetails(Region):
 
-            _job_details_panel_locator = (By.ID, 'job-details-panel')
+            _root_locator = (By.ID, 'job-details-panel')
             _job_keyword_locator = (By.CSS_SELECTOR, '#job-details-pane > ul > li > a:nth-last-child(1)')
             _job_result_status_locator = (By.CSS_SELECTOR, '#result-status-pane > div:nth-child(1) > span:nth-child(2)')
             _logviewer_button_locator = (By.ID, 'logviewer-btn')
@@ -415,7 +415,7 @@ class TreeherderPage(Base):
                 self.find_element(*self._job_keyword_locator).click()
 
             def open_logviewer(self):
-                self.find_element(*self._job_details_panel_locator).send_keys('l')
+                self.root.send_keys('l')
                 window_handles = self.selenium.window_handles
                 for handle in window_handles:
                     self.selenium.switch_to.window(handle)

--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -19,11 +19,13 @@ class TreeherderPage(Base):
     _clear_filter_locator = (By.ID, 'quick-filter-clear-button')
     _close_the_job_panel_locator = (By.CSS_SELECTOR, '.info-panel-navbar-controls > li:nth-child(2)')
     _filter_panel_all_failures_locator = (By.CSS_SELECTOR, '.pull-right input')
+    _filter_panel_body_locator = (By.CSS_SELECTOR, '.th-top-nav-options-panel')
     _filter_panel_busted_failures_locator = (By.ID, 'busted')
     _filter_panel_exception_failures_locator = (By.ID, 'exception')
     _filter_panel_locator = (By.CSS_SELECTOR, 'span.navbar-right > span:nth-child(4)')
     _filter_panel_reset_locator = (By.CSS_SELECTOR, '.pull-right span:nth-child(3)')
     _filter_panel_testfailed_failures_locator = (By.ID, 'testfailed')
+    _info_panel_content_locator = (By.ID, 'info-panel-content')
     _mozilla_central_repo_locator = (By.CSS_SELECTOR, '#th-global-navbar-top a[href*="mozilla-central"]')
     _nav_filter_coalesced_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=coalesced]')
     _nav_filter_failures_locator = (By.CSS_SELECTOR, '.btn-nav-filter[title=failures]')
@@ -70,8 +72,18 @@ class TreeherderPage(Base):
         return self.find_element(*self._filter_panel_testfailed_failures_locator).is_selected()
 
     @property
+    def filter_panel_is_open(self):
+        el = self.find_element(*self._filter_panel_body_locator)
+        return el.is_displayed()
+
+    @property
     def job_details(self):
         return self.JobDetails(self)
+
+    @property
+    def info_panel_is_open(self):
+        el = self.find_element(*self._info_panel_content_locator)
+        return el.is_displayed()
 
     @property
     def nav_filter_coalesced_is_selected(self):
@@ -117,6 +129,11 @@ class TreeherderPage(Base):
         return [self.ResultSet(self, el) for el in self.find_elements(*self._result_sets_locator)]
 
     @property
+    def search_term(self):
+        el = self.find_element(*self._quick_filter_locator)
+        return el.get_attribute('value')
+
+    @property
     def unchecked_repos(self):
         return self.find_elements(*self._unchecked_repos_links_locator)
 
@@ -124,8 +141,14 @@ class TreeherderPage(Base):
     def unclassified_failure_count(self):
         return int(self.find_element(*self._unclassified_failure_count_locator).text)
 
-    def clear_filter(self):
-        self.selenium.find_element(*self._clear_filter_locator).click()
+    def clear_filter(self, method='pointer'):
+        if method == 'pointer':
+            self.selenium.find_element(*self._clear_filter_locator).click()
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                Keys.CONTROL + Keys.SHIFT + 'f')
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
 
     def click_on_filters_panel(self):
         self.find_element(*self._filter_panel_locator).click()
@@ -136,6 +159,9 @@ class TreeherderPage(Base):
 
     def close_the_job_panel(self):
         self.find_element(*self._close_the_job_panel_locator).click()
+
+    def close_all_panels(self):
+        self.find_element(By.CSS_SELECTOR, 'body').send_keys(Keys.ESCAPE)
 
     def deselect_all_failures(self):
         """Filters Panel must be opened"""
@@ -153,11 +179,17 @@ class TreeherderPage(Base):
         """Filters Panel must be opened"""
         self.find_element(*self._filter_panel_testfailed_failures_locator).click()
 
-    def filter_by(self, term):
-        el = self.selenium.find_element(*self._quick_filter_locator)
-        el.send_keys(term)
-        el.send_keys(Keys.RETURN)
-        self.wait.until(lambda s: self.result_sets)
+    def filter_by(self, term, method='pointer'):
+        if method == 'pointer':
+            el = self.selenium.find_element(*self._quick_filter_locator)
+            el.send_keys(term)
+            el.send_keys(Keys.RETURN)
+            self.wait.until(lambda s: self.result_sets)
+        elif method == 'keyboard':
+            self.find_element(By.CSS_SELECTOR, 'body').send_keys(
+                'f' + term + Keys.RETURN)
+        else:
+            raise Exception('Unsupported method: {}'.format(method))
 
     def filter_job_coalesced(self):
         self.find_element(*self._nav_filter_coalesced_locator).click()

--- a/pages/treeherder.py
+++ b/pages/treeherder.py
@@ -80,10 +80,6 @@ class TreeherderPage(Base):
         return self.InfoPanel(self)
 
     @property
-    def job_details(self):
-        return self.JobDetails(self)
-
-    @property
     def nav_filter_coalesced_is_selected(self):
         el = self.find_element(*self._nav_filter_coalesced_locator)
         return ('fa-dot-circle-o' in el.get_attribute('class'))
@@ -226,7 +222,7 @@ class TreeherderPage(Base):
         el = self.find_element(*self._result_sets_locator)
         self.wait.until(EC.visibility_of(el))
         el.send_keys('n')
-        self.wait.until(lambda s: self.job_details.job_result_status)
+        self.wait.until(lambda s: self.info_panel.job_details.job_result_status)
 
     def open_perfherder_page(self):
         self.header.switch_page_using_dropdown()
@@ -376,7 +372,7 @@ class TreeherderPage(Base):
 
             def click(self):
                 self.root.click()
-                self.wait.until(lambda _: self.page.job_details.job_result_status)
+                self.wait.until(lambda _: self.page.info_panel.job_details.job_result_status)
 
     class InfoPanel(Region):
 
@@ -389,34 +385,46 @@ class TreeherderPage(Base):
     class JobDetails(Region):
         """TODO: Move region under InfoPanel"""
 
-        _job_details_panel_locator = (By.ID, 'job-details-panel')
-        _job_keyword_locator = (By.CSS_SELECTOR, '#job-details-pane > ul > li > a:nth-last-child(1)')
-        _job_result_status_locator = (By.CSS_SELECTOR, '#result-status-pane > div:nth-child(1) > span:nth-child(2)')
-        _logviewer_button_locator = (By.ID, 'logviewer-btn')
-        _pin_job_locator = (By.ID, 'pin-job-btn')
+        _root_locator = (By.ID, 'info-panel-content')
 
         @property
-        def job_keyword_name(self):
-            return self.find_element(*self._job_keyword_locator).text
+        def is_open(self):
+            return self.root.is_displayed()
 
         @property
-        def job_result_status(self):
-            return self.find_element(*self._job_result_status_locator).text
+        def job_details(self):
+            return self.JobDetails(self)
 
-        def filter_by_job_keyword(self):
-            self.find_element(*self._job_keyword_locator).click()
+        class JobDetails(Region):
 
-        def open_logviewer(self):
-            self.find_element(*self._job_details_panel_locator).send_keys('l')
-            window_handles = self.selenium.window_handles
-            for handle in window_handles:
-                self.selenium.switch_to.window(handle)
-            return LogviewerPage(self.selenium, self.page.base_url).wait_for_page_to_load()
+            _job_details_panel_locator = (By.ID, 'job-details-panel')
+            _job_keyword_locator = (By.CSS_SELECTOR, '#job-details-pane > ul > li > a:nth-last-child(1)')
+            _job_result_status_locator = (By.CSS_SELECTOR, '#result-status-pane > div:nth-child(1) > span:nth-child(2)')
+            _logviewer_button_locator = (By.ID, 'logviewer-btn')
+            _pin_job_locator = (By.ID, 'pin-job-btn')
 
-        def pin_job(self):
-            el = self.find_element(*self._job_keyword_locator)
-            self.wait.until(EC.visibility_of(el))
-            self.find_element(*self._pin_job_locator).click()
+            @property
+            def job_keyword_name(self):
+                return self.find_element(*self._job_keyword_locator).text
+
+            @property
+            def job_result_status(self):
+                return self.find_element(*self._job_result_status_locator).text
+
+            def filter_by_job_keyword(self):
+                self.find_element(*self._job_keyword_locator).click()
+
+            def open_logviewer(self):
+                self.find_element(*self._job_details_panel_locator).send_keys('l')
+                window_handles = self.selenium.window_handles
+                for handle in window_handles:
+                    self.selenium.switch_to.window(handle)
+                return LogviewerPage(self.selenium, self.page.base_url).wait_for_page_to_load()
+
+            def pin_job(self):
+                el = self.find_element(*self._job_keyword_locator)
+                self.wait.until(EC.visibility_of(el))
+                self.find_element(*self._pin_job_locator).click()
 
     class Pinboard(Region):
 

--- a/tests/test_filter_job_by_keywords.py
+++ b/tests/test_filter_job_by_keywords.py
@@ -14,8 +14,8 @@ def test_filter_by_job_keyword(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
     page.select_random_job()
 
-    page.job_details.filter_by_job_keyword()
-    keyword = page.job_details.job_keyword_name
+    page.info_panel.job_details.filter_by_job_keyword()
+    keyword = page.info_panel.job_details.job_keyword_name
 
     page.select_random_job()
-    assert keyword in page.job_details.job_keyword_name
+    assert keyword in page.info_panel.job_details.job_keyword_name

--- a/tests/test_filter_panel.py
+++ b/tests/test_filter_panel.py
@@ -20,7 +20,7 @@ def test_filter_by_test_status(base_url, selenium):
     page.deselect_exception_failures()
     if len(page.all_jobs) > 0:
         page.open_next_unclassified_failure()
-        assert 'testfailed' == page.job_details.job_result_status
+        assert 'testfailed' == page.info_panel.job_details.job_result_status
 
     # Test 'busted' unclassified failures
     page.select_busted_failures()
@@ -28,7 +28,7 @@ def test_filter_by_test_status(base_url, selenium):
     if len(page.all_jobs) > 0:
         page.close_the_job_panel()
         page.open_next_unclassified_failure()
-        assert 'busted' == page.job_details.job_result_status
+        assert 'busted' == page.info_panel.job_details.job_result_status
 
     # Test 'exception' unclassified failures
     page.select_exception_failures()
@@ -36,7 +36,7 @@ def test_filter_by_test_status(base_url, selenium):
     if len(page.all_jobs) > 0:
         page.close_the_job_panel()
         page.open_next_unclassified_failure()
-        assert 'exception' == page.job_details.job_result_status
+        assert 'exception' == page.info_panel.job_details.job_result_status
 
 
 @pytest.mark.nondestructive

--- a/tests/test_keyboard_shortcuts.py
+++ b/tests/test_keyboard_shortcuts.py
@@ -7,6 +7,53 @@ import random
 from pages.treeherder import TreeherderPage
 
 
+def test_close_open_panels(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'Esc' closes filter and job panel.
+    Open Treeherder page, open Filters panel, select random job, close all
+    panels using 'esc' button, verify if all panels are closed.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.click_on_filters_panel()
+    page.select_random_job()
+
+    assert page.filter_panel_is_open
+    assert page.info_panel_is_open
+
+    page.close_all_panels()
+
+    assert not page.filter_panel_is_open
+    assert not page.info_panel_is_open
+
+
+def test_enter_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: 'f' moves cursor to filter search box.
+    Open Treeherder page, verify if search box is empty, enter search box
+    filter using 'f' shortcut, type 'debug', verify if filter box contains
+    word Mozilla.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+    assert page.search_term == ''
+
+    page.filter_by('debug', method='keyboard')
+    assert page.search_term == 'debug'
+
+
+def test_clear_the_quick_filter_shortcut(base_url, selenium):
+    """Open Treeherder, verify shortcut: CTRL + SHIFT + 'f' clears the filter search box.
+    Open Treeherder page, filter by 'Mozdebugilla', verify if filter box contains the
+    word 'debug', clear the quick filter using CTRL + SHIFT + f shortcut,
+    verify if search box is empty.
+    """
+    page = TreeherderPage(selenium, base_url).open()
+
+    page.filter_by('debug', method='keyboard')
+    assert page.search_term == 'debug'
+
+    page.clear_filter(method='keyboard')
+    assert page.search_term == ''
+
+
 def test_next_job_shortcut(base_url, selenium):
     """Open Treeherder, verify shortcut: 'Right Arrow' opens next job.
     Open Treeherder page, select random job and get the keyword name, select next job

--- a/tests/test_pin_job.py
+++ b/tests/test_pin_job.py
@@ -22,7 +22,7 @@ def test_pin_job_from_job_details(base_url, selenium):
     job = page.result_sets[0].jobs[0]
     job.click()
     assert 0 == len(page.pinboard.jobs)
-    page.job_details.pin_job()
+    page.info_panel.job_details.pin_job()
     assert 1 == len(page.pinboard.jobs)
     assert job.symbol == page.pinboard.selected_job.symbol
 

--- a/tests/test_unclassified_job.py
+++ b/tests/test_unclassified_job.py
@@ -14,7 +14,7 @@ def test_unclassified_failure(base_url, selenium):
     page = TreeherderPage(selenium, base_url).open()
     assert page.unclassified_failure_count > 0
     page.open_next_unclassified_failure()
-    teststatus = page.job_details.job_result_status
+    teststatus = page.info_panel.job_details.job_result_status
     assert teststatus in ['busted', 'testfailed', 'exception']
 
 
@@ -24,7 +24,7 @@ def test_open_unclassified_failure_log(base_url, selenium):
     treeherder_page = TreeherderPage(selenium, base_url).open()
     assert treeherder_page.unclassified_failure_count > 0
     treeherder_page.open_next_unclassified_failure()
-    logviewer_page = treeherder_page.job_details.open_logviewer()
+    logviewer_page = treeherder_page.info_panel.job_details.open_logviewer()
     assert logviewer_page.is_job_status_visible
 
 


### PR DESCRIPTION
Tests pass except test_unclassified_job.py. This gives an error on switching the window that I don't know how to fix- the logviewer page does open correctly.

```
    def open_logviewer(self):
        self.find_element(*self._job_details_panel_locator).send_keys('l')
        window_handles = self.selenium.window_handles
        for handle in window_handles:
            self.selenium.switch_to.window(handle)
>       return LogviewerPage(self.selenium, self.page.base_url).wait_for_page_to_load()
E       AttributeError: 'InfoPanel' object has no attribute 'base_url'

pages/treeherder.py:414: AttributeError
------------------------------------------- pytest-selenium --------------------------------------------
URL: https://treeherder.allizom.org/logviewer.html#?job_id=78079209&repo=mozilla-inbound
================================= 1 failed, 2 passed in 17.98 seconds ==================================
ERROR: InvocationError: '/Users/rebeccabillings/github/treeherder-tests/.tox/tests/bin/pytest --junit-xml=results/tests.xml --html=results/tests.html --base-url https://treeherder.allizom.org tests/test_unclassified_job.py'
```